### PR TITLE
fix: present stacktraces as continuous instead of 2 blocks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -179,10 +179,10 @@ func (ew *stackErrorWriter) Error(msg, metadata, location string, st *stacktrace
 	fmt.Fprintf(ew.writer, "\tat %s", location)
 	ew.firstLinePrinted = true
 
-	if st != nil {
-		fmt.Fprintf(ew.writer, "\n\tStacktrace:\n")
+	if st != nil && len(st.frames) > 0 {
+		fmt.Fprintf(ew.writer, "\n")
 		for i, frame := range st.frames {
-			fmt.Fprintf(ew.writer, "\t\t%s", frame.String())
+			fmt.Fprintf(ew.writer, "\tat %s", frame.String())
 			if i < len(st.frames)-1 {
 				fmt.Fprintf(ew.writer, "\n")
 			}

--- a/errors_test.go
+++ b/errors_test.go
@@ -288,7 +288,6 @@ func TestErrorWithStacktrace(t *testing.T) {
 
 	a.Regexp(fmt.Sprintf(`failure
 \s+at.+/metaerr/errors_test.go:%d
-\s+Stacktrace:
 \s+.+/metaerr/errors_test.go:%d
 \s+.+/metaerr/errors_test.go:.*
 `,


### PR DESCRIPTION
Just a quick fix to remove the unnecessary "Stacktrace" text when formatting errors. We can just present the stacktrace as one unified list.