### PR TITLE
feat: add non formatting methods for golang 1.24 govet

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -30,9 +30,19 @@ func (b Builder) Context(ctx context.Context) Builder {
 	}
 }
 
+func (b Builder) New(msg string) error {
+	opts := append(b.opts, WithMeta(b.metas...), WithContext(b.context))
+	return New(msg, opts...)
+}
+
 func (b Builder) Newf(format string, args ...any) error {
 	opts := append(b.opts, WithMeta(b.metas...), WithContext(b.context))
 	return New(fmt.Sprintf(format, args...), opts...)
+}
+
+func (b Builder) Wrap(err error, msg string) error {
+	opts := append(b.opts, WithMeta(b.metas...), WithContext(b.context))
+	return Wrap(err, msg, opts...)
 }
 
 func (b Builder) Wrapf(err error, format string, args ...any) error {

--- a/builder_test.go
+++ b/builder_test.go
@@ -3,9 +3,10 @@ package metaerr_test
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/quantumcycle/metaerr"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestBuilderNewWithMeta(t *testing.T) {
@@ -14,7 +15,7 @@ func TestBuilderNewWithMeta(t *testing.T) {
 	tagMeta := metaerr.StringMeta("tags")
 	builder := metaerr.NewBuilder().Meta(tagMeta("security"), tagMeta("db"))
 
-	err := builder.Newf("failure")
+	err := builder.New("failure")
 
 	a.Equal("failure [tags=db,security]", err.Error())
 }
@@ -26,9 +27,32 @@ func TestBuilderNewWithContext(t *testing.T) {
 	builder := metaerr.NewBuilder().Meta(ctxTagMeta())
 
 	ctx := context.WithValue(context.Background(), "tag", "security")
-	err := builder.Context(ctx).Newf("failure")
+	err := builder.Context(ctx).New("failure")
 
 	a.Equal("failure [tag=security]", err.Error())
+}
+
+func TestBuilderNewfWithMeta(t *testing.T) {
+	a := assert.New(t)
+
+	tagMeta := metaerr.StringMeta("tags")
+	builder := metaerr.NewBuilder().Meta(tagMeta("security"), tagMeta("db"))
+
+	err := builder.Newf("failure %s", "test")
+
+	a.Equal("failure test [tags=db,security]", err.Error())
+}
+
+func TestBuilderNewfWithContext(t *testing.T) {
+	a := assert.New(t)
+
+	ctxTagMeta := metaerr.StringMetaFromContext("tag", "tag")
+	builder := metaerr.NewBuilder().Meta(ctxTagMeta())
+
+	ctx := context.WithValue(context.Background(), "tag", "security")
+	err := builder.Context(ctx).Newf("failure %s", "test")
+
+	a.Equal("failure test [tag=security]", err.Error())
 }
 
 func TestBuilderWrapWithMeta(t *testing.T) {
@@ -37,7 +61,7 @@ func TestBuilderWrapWithMeta(t *testing.T) {
 	tagMeta := metaerr.StringMeta("tags")
 	builder := metaerr.NewBuilder().Meta(tagMeta("security")).Meta(tagMeta("db"))
 
-	err := builder.Wrapf(errors.New("failure"), "wrapped")
+	err := builder.Wrap(errors.New("failure"), "wrapped")
 
 	a.Equal("wrapped [tags=db,security]: failure", err.Error())
 }
@@ -48,7 +72,29 @@ func TestBuilderWrapWithoutErr(t *testing.T) {
 	tagMeta := metaerr.StringMeta("tags")
 	builder := metaerr.NewBuilder().Meta(tagMeta("security"), tagMeta("db"))
 
-	err := builder.Wrapf(nil, "wrapped")
+	err := builder.Wrap(nil, "wrapped")
+
+	a.Nil(err)
+}
+
+func TestBuilderWrapfWithMeta(t *testing.T) {
+	a := assert.New(t)
+
+	tagMeta := metaerr.StringMeta("tags")
+	builder := metaerr.NewBuilder().Meta(tagMeta("security")).Meta(tagMeta("db"))
+
+	err := builder.Wrapf(errors.New("failure"), "wrapped %s", "test")
+
+	a.Equal("wrapped test [tags=db,security]: failure", err.Error())
+}
+
+func TestBuilderWrapfWithoutErr(t *testing.T) {
+	a := assert.New(t)
+
+	tagMeta := metaerr.StringMeta("tags")
+	builder := metaerr.NewBuilder().Meta(tagMeta("security"), tagMeta("db"))
+
+	err := builder.Wrapf(nil, "wrapped %s", "test")
 
 	a.Nil(err)
 }


### PR DESCRIPTION
Golang 1.24 now requires values to be pass to formatting methods. You can't do `Newf("something")`. To bypass this, I added `New` and `Wrap` to the builder in addition to the existing `Newf` and `Wrapf` methods