### PR TITLE
fix: change how metaerr details stdlib packages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ func Wrap(err error, msg string, opt ...Option) error {
 
 	e := Error{
 		Reason:   msg,
-		Location: getLocation(0),
+		Location: getLocation(0, nil),
 		Cause:    err,
 	}
 
@@ -80,6 +80,11 @@ type Error struct {
 	Stacktrace *Stacktrace
 	Cause      error
 	Metas      []ErrorMetadata
+	// rootDetector classifies whether an import path is a stack-terminating
+	// "root" package (stdlib/runtime). nil means DefaultRootPackage. Set via
+	// WithRootPackageDetector; must be applied before WithLocationSkip /
+	// WithStackTrace to take effect (those capture eagerly).
+	rootDetector func(pkg string) bool
 }
 
 func (e Error) Unwrap() error {
@@ -160,7 +165,7 @@ func (e Error) Format(s fmt.State, verb rune) {
 func New(reason string, opt ...Option) error {
 	e := Error{
 		Reason:   reason,
-		Location: getLocation(0),
+		Location: getLocation(0, nil),
 	}
 
 	if len(opt) > 0 {
@@ -172,8 +177,8 @@ func New(reason string, opt ...Option) error {
 	return e
 }
 
-func getLocation(callerSkip int) string {
-	st := newStacktrace(callerSkip, 1)
+func getLocation(callerSkip int, isRoot func(pkg string) bool) string {
+	st := newStacktrace(callerSkip, 1, isRoot)
 	if len(st.Frames) == 0 {
 		return ""
 	}
@@ -198,7 +203,10 @@ type internal struct{}
 
 var internalPath = reflect.TypeOf(internal{}).PkgPath()
 
-func newStacktrace(frameStackSkip, maxDepth int) *Stacktrace {
+func newStacktrace(frameStackSkip, maxDepth int, isRoot func(pkg string) bool) *Stacktrace {
+	if isRoot == nil {
+		isRoot = DefaultRootPackage
+	}
 	var frames []Frame
 	var index = 0
 
@@ -216,12 +224,21 @@ func newStacktrace(frameStackSkip, maxDepth int) *Stacktrace {
 		index++
 	}
 
-	// We loop until we have StackTraceMaxDepth frames or we run out of frames.
-	// Frames from this package are skipped.
+	// Collect frames up to maxDepth, stopping once we reach the stdlib/runtime
+	// (it won't call back into user code).
+	//
+	// We always keep the FIRST frame and only apply the stdlib check from the
+	// second one on. The first frame is the site that created the error, which is
+	// user code by construction (the stdlib never calls into metaerr). This makes
+	// the worst case graceful: the root classifier can misclassify user code in
+	// a domain-less module (see DefaultRootPackage), and without this guard such
+	// a frame would be dropped, leaving an empty stack / location.
 	for i := index + frameStackSkip; len(frames) < maxDepth; i++ {
-		_, file, line, ok := runtime.Caller(i)
-		//Once we find a frame in the stdlib, we stop, since stdlib code won't call back to user code
-		if !ok || strings.Contains(file, runtime.GOROOT()) {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		if len(frames) > 0 && isRootFrame(pc, isRoot) {
 			break
 		}
 
@@ -234,4 +251,53 @@ func newStacktrace(frameStackSkip, maxDepth int) *Stacktrace {
 	return &Stacktrace{
 		Frames: frames,
 	}
+}
+
+// packageOf returns the import path of the package a fully-qualified function
+// name belongs to.
+//
+//	"net/http.(*conn).serve"              -> "net/http"
+//	"runtime.main"                        -> "runtime"
+//	"github.com/quantumcycle/metaerr.New" -> "github.com/quantumcycle/metaerr"
+func packageOf(funcName string) string {
+	// The function/method part starts at the first '.' that follows the last '/'.
+	if slash := strings.LastIndexByte(funcName, '/'); slash >= 0 {
+		if dot := strings.IndexByte(funcName[slash:], '.'); dot >= 0 {
+			return funcName[:slash+dot]
+		}
+		return funcName
+	}
+	if dot := strings.IndexByte(funcName, '.'); dot >= 0 {
+		return funcName[:dot]
+	}
+	return funcName
+}
+
+func isRootFrame(pc uintptr, isRoot func(pkg string) bool) bool {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return false
+	}
+	return isRoot(packageOf(fn.Name()))
+}
+
+// DefaultRootPackage is the default root-package classifier, used when none is
+// configured via WithRootPackageDetector. It reports whether an import path
+// belongs to the standard library or runtime — i.e. where stack capture stops.
+//
+// Stdlib import paths have no domain (no '.') in their first
+// path segment ("runtime", "net/http", "testing"), whereas conventional module
+// paths do ("github.com/...", "golang.org/x/..."). This is not fullproof.
+// Modules declared with a domain-less path (e.g. `go mod init myapp` → "myapp",
+// "internal/foo") are indistinguishable from the stdlib by this rule and are
+// classified as a root.
+func DefaultRootPackage(pkg string) bool {
+	if pkg == "main" {
+		return false
+	}
+	first := pkg
+	if slash := strings.IndexByte(pkg, '/'); slash >= 0 {
+		first = pkg[:slash]
+	}
+	return !strings.Contains(first, ".")
 }

--- a/options.go
+++ b/options.go
@@ -7,14 +7,37 @@ type Option func(*Error)
 func WithLocationSkip(additionalCallerSkip int) Option {
 	return func(e *Error) {
 		//+1 since this is called from the option
-		e.Location = getLocation(additionalCallerSkip)
+		e.Location = getLocation(additionalCallerSkip, e.rootDetector)
 	}
 }
 
 func WithStackTrace(additionalCallerSkip, maxDepth int) Option {
 	return func(e *Error) {
 		//+1 because we always skip the first frame since it will be the same as the location
-		e.Stacktrace = newStacktrace(additionalCallerSkip+1, maxDepth)
+		e.Stacktrace = newStacktrace(additionalCallerSkip+1, maxDepth, e.rootDetector)
+	}
+}
+
+// WithRootPackageDetector overrides how stack capture decides a frame's package
+// is a stack-terminating "root" (standard library / runtime). isRoot receives an
+// import path (e.g. "net/http", "github.com/x/y") and returns true to stop the
+// walk there. When unset, DefaultRootPackage is used.
+//
+// Use it for projects whose module path has no domain (e.g. `go mod init myapp`),
+// which DefaultRootPackage would otherwise mistake for the standard library:
+//
+//	metaerr.WithRootPackageDetector(func(pkg string) bool {
+//		if strings.HasPrefix(pkg, "myapp") {
+//			return false // my code, keep walking
+//		}
+//		return metaerr.DefaultRootPackage(pkg)
+//	})
+//
+// Capture is eager, so this option must be applied BEFORE WithLocationSkip /
+// WithStackTrace. A Builder applies its options in order, so list it first.
+func WithRootPackageDetector(isRoot func(pkg string) bool) Option {
+	return func(e *Error) {
+		e.rootDetector = isRoot
 	}
 }
 

--- a/roots_test.go
+++ b/roots_test.go
@@ -1,0 +1,43 @@
+package metaerr_test
+
+import (
+	"testing"
+
+	"github.com/quantumcycle/metaerr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureWith(detector func(string) bool) *metaerr.Stacktrace {
+	err := metaerr.New("boom",
+		metaerr.WithRootPackageDetector(detector),
+		metaerr.WithStackTrace(0, 10),
+	)
+	me, _ := metaerr.AsMetaError(err)
+	return me.Stacktrace
+}
+
+func TestWithRootPackageDetectorControlsCapture(t *testing.T) {
+	// Treating every package as a root: the walk stops at the second frame, so
+	// the keep-first guarantee leaves exactly the one captured call-site frame.
+	allRoot := captureWith(func(string) bool { return true })
+	require.NotNil(t, allRoot)
+	assert.Len(t, allRoot.Frames, 1,
+		"an all-root detector should yield only the kept first frame")
+
+	// Treating nothing as a root: the walk continues past the first frame (into
+	// the test runner / runtime) up to maxDepth.
+	noneRoot := captureWith(func(string) bool { return false })
+	require.NotNil(t, noneRoot)
+	assert.Greater(t, len(noneRoot.Frames), 1,
+		"a no-root detector should keep walking past the first frame")
+}
+
+// TestDefaultRootPackageComposable documents that the default classifier is
+// exported so a custom detector can delegate to it for everything it doesn't
+// special-case (the common pattern for a domain-less module).
+func TestDefaultRootPackageComposable(t *testing.T) {
+	assert.True(t, metaerr.DefaultRootPackage("net/http"))
+	assert.False(t, metaerr.DefaultRootPackage("github.com/x/y"))
+	assert.False(t, metaerr.DefaultRootPackage("main"))
+}

--- a/stacktrace_internal_test.go
+++ b/stacktrace_internal_test.go
@@ -1,0 +1,82 @@
+package metaerr
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestPackageOf(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"runtime.main", "runtime"},
+		{"testing.tRunner", "testing"},
+		{"net/http.(*conn).serve", "net/http"},
+		{"github.com/quantumcycle/metaerr.New", "github.com/quantumcycle/metaerr"},
+		{"github.com/quantumcycle/metaerr.(*Error).Error", "github.com/quantumcycle/metaerr"},
+		{"github.com/x/y.Outer.func1", "github.com/x/y"},
+		{"main.main", "main"},
+		{"main", "main"},
+		{"runtime", "runtime"},
+	}
+	for _, c := range cases {
+		if got := packageOf(c.name); got != c.want {
+			t.Errorf("packageOf(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestDefaultRootPackage(t *testing.T) {
+	cases := []struct {
+		pkg  string
+		want bool
+	}{
+		// standard library / runtime
+		{"runtime", true},
+		{"testing", true},
+		{"net/http", true},
+		{"internal/poll", true},
+		// conventional user modules (have a domain)
+		{"github.com/quantumcycle/metaerr", false},
+		{"golang.org/x/net/http2", false},
+		{"main", false},
+		// KNOWN LIMITATION: a domain-less module path is indistinguishable from
+		// the stdlib by this heuristic and is classified as a root. The keep-first
+		// rule and WithRootPackageDetector keep this from emptying a stack.
+		{"myapp", true},
+		{"internal/foo", true},
+	}
+	for _, c := range cases {
+		if got := DefaultRootPackage(c.pkg); got != c.want {
+			t.Errorf("DefaultRootPackage(%q) = %v, want %v", c.pkg, got, c.want)
+		}
+	}
+}
+
+func aUserFuncForStackTest() {}
+
+// TestIsRootFrameClassifiesByPackage guards the -trimpath regression: frame
+// classification must not depend on file paths or runtime.GOROOT() (both of
+// which -trimpath defeats), only on the import-path-based symbol name.
+func TestIsRootFrameClassifiesByPackage(t *testing.T) {
+	stdlibPC := reflect.ValueOf(fmt.Sprintf).Pointer()
+	if !isRootFrame(stdlibPC, DefaultRootPackage) {
+		t.Errorf("fmt.Sprintf must be classified as a root frame (name=%q)",
+			runtime.FuncForPC(stdlibPC).Name())
+	}
+
+	userPC := reflect.ValueOf(aUserFuncForStackTest).Pointer()
+	if isRootFrame(userPC, DefaultRootPackage) {
+		t.Errorf("a user-package func must not be a root frame (name=%q)",
+			runtime.FuncForPC(userPC).Name())
+	}
+}
+
+func TestIsRootFrameNilFunc(t *testing.T) {
+	if isRootFrame(0, DefaultRootPackage) {
+		t.Error("zero PC (FuncForPC == nil) must not be a root frame")
+	}
+}


### PR DESCRIPTION
To make it work with -trimpath compiler option